### PR TITLE
Allow specifying a target other than document

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ const PCancelable = require('p-cancelable');
 
 const selectorCache = new Map();
 
-module.exports = selector => {
+module.exports = (selector, options) => {
+	options = Object.assign({
+		target: document
+	}, options);
+
 	if (selectorCache.has(selector)) {
 		return selectorCache.get(selector);
 	}
@@ -16,7 +20,7 @@ module.exports = selector => {
 
 		// Interval to keep checking for it to come into the DOM
 		(function check() {
-			const el = document.querySelector(selector);
+			const el = options.target.querySelector(selector);
 
 			if (el) {
 				resolve(el);

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ elementReady('#unicorn').then(element => {
 
 ## API
 
-### elementReady(selector)
+### elementReady(selector, [options])
 
 Returns a promise for a matching element.
 
@@ -33,6 +33,17 @@ Returns a promise for a matching element.
 Type: `string`
 
 [CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
+
+#### options
+
+Type: `Object`
+
+##### target
+
+Type: `Element`, `document`<br>
+Default: `document`
+
+The element that's expected to contain a match.
 
 ### elementReadyPromise#cancel()
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Type: `Object`
 
 ##### target
 
-Type: `Element`, `document`<br>
+Type: `Element` `document`<br>
 Default: `document`
 
 The element that's expected to contain a match.

--- a/test.js
+++ b/test.js
@@ -22,6 +22,22 @@ test('check if element ready', async t => {
 	t.is(el.id, 'unicorn');
 });
 
+test('check if element ready inside target', async t => {
+	const target = document.createElement('p');
+	const elCheck = m('#unicorn', {
+		target
+	});
+
+	delay(500).then(() => {
+		const el = document.createElement('p');
+		el.id = 'unicorn';
+		target.appendChild(el);
+	});
+
+	const el = await elCheck;
+	t.is(el.id, 'unicorn');
+});
+
 test('ensure only one promise is returned on multiple calls passing the same selector', t => {
 	const elCheck = m('#unicorn');
 


### PR DESCRIPTION
This could be done without `Object.assign` but that opens the door for #8