### PR TITLE
Fix element selection when same selector is used in different targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const PCancelable = require('p-cancelable');
 
-const targetCache = new Map();
+const targetCache = new WeakMap();
 
 const cleanCache = (target, selector) => {
 	targetCache.get(target).delete(selector);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ const PCancelable = require('p-cancelable');
 
 const targetCache = new Map();
 
+const cleanCache = (target, selector) => {
+	targetCache.get(target).delete(selector);
+	if (!targetCache.get(target).size) {
+		targetCache.delete(target);
+	}
+};
+
 module.exports = (selector, options) => {
 	options = Object.assign({
 		target: document
@@ -16,6 +23,7 @@ module.exports = (selector, options) => {
 		let raf;
 		onCancel(() => {
 			cancelAnimationFrame(raf);
+			cleanCache(options.target, selector);
 		});
 
 		// Interval to keep checking for it to come into the DOM
@@ -24,10 +32,7 @@ module.exports = (selector, options) => {
 
 			if (el) {
 				resolve(el);
-				targetCache.get(options.target).delete(selector);
-				if (!targetCache.get(options.target).size) {
-					targetCache.delete(options.target);
-				}
+				cleanCache(options.target, selector);
 			} else {
 				raf = requestAnimationFrame(check);
 			}

--- a/test.js
+++ b/test.js
@@ -39,6 +39,35 @@ test('check if element ready inside target', async t => {
 	t.is(el.id, 'unicorn');
 });
 
+test('check if different elements ready inside different targets with same selector', async t => {
+	const target1 = document.createElement('p');
+	const elCheck1 = m('.unicorn', {
+		target: target1
+	});
+	const target2 = document.createElement('span');
+	const elCheck2 = m('.unicorn', {
+		target: target2
+	});
+
+	delay(500).then(() => {
+		const el1 = document.createElement('p');
+		el1.id = 'unicorn1';
+		el1.className = 'unicorn';
+		target1.appendChild(el1);
+
+		const el2 = document.createElement('span');
+		el2.id = 'unicorn2';
+		el2.className = 'unicorn';
+		target2.appendChild(el2);
+	});
+
+	const el1 = await elCheck1;
+	t.is(el1.id, 'unicorn1');
+
+	const el2 = await elCheck2;
+	t.is(el2.id, 'unicorn2');
+});
+
 test('ensure only one promise is returned on multiple calls passing the same selector', t => {
 	const elCheck = m('#unicorn');
 

--- a/test.js
+++ b/test.js
@@ -93,3 +93,14 @@ test('check if wait can be canceled', async t => {
 
 	await t.throws(elCheck, PCancelable.CancelError);
 });
+
+test('ensure different promises are returned on second call with the same selector when first was cancelled', async t => {
+	const elCheck1 = m('.unicorn');
+
+	elCheck1.cancel();
+
+	const elCheck2 = m('.unicorn');
+
+	await t.throws(elCheck1, PCancelable.CancelError);
+	t.true(elCheck1 !== elCheck2);
+});


### PR DESCRIPTION
In the previous behavior, `elementReady` returns the wrong element when calling it with the same selector, but in different targets

Fixes #10 

----

1. The caching implementation got a little convoluted because of the nature of the problem. If anyone has any suggestions to make it more readable let me know!
2. Is there any edge-case that I didn't consider?
3. Does anyone think it's necessary to add a more complex test?
4. Also, shouldn't we clean the cache in the `onCancel` event as well?

Pinging @bfred-it , who also worked in this