### PR TITLE
Simplify with `many-keys-map`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const ManyKeysMap = require('many-keys-map');
 
 const cache = new ManyKeysMap();
 
-
 const elementReady = (selector, options) => {
 	const {target} = Object.assign({
 		target: document

--- a/index.js
+++ b/index.js
@@ -9,12 +9,13 @@ module.exports = (selector, options) => {
 		target: document
 	}, options);
 
-	if (cache.has([target, selector])) {
-		return cache.get([target, selector]);
+	let promise = cache.get([target, selector]);
+	if (promise) {
+		return promise;
 	}
 
 	let alreadyFound = false;
-	const promise = new PCancelable((resolve, reject, onCancel) => {
+	promise = new PCancelable((resolve, reject, onCancel) => {
 		let raf;
 		onCancel(() => {
 			cancelAnimationFrame(raf);

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
 		"envs": [
 			"node",
 			"browser"
-		],
-		"rules": {
-			"unicorn/prefer-node-append": 0
-		}
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"check"
 	],
 	"dependencies": {
+		"many-keys-map": "^1.0.0",
 		"p-cancelable": "^0.4.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
 		"envs": [
 			"node",
 			"browser"
-		]
+		],
+		"rules": {
+			"unicorn/prefer-node-append": 0
+		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -91,7 +91,7 @@ test('check if wait can be canceled', async t => {
 	el.id = 'dofle';
 	document.body.appendChild(el);
 
-	await t.throws(elCheck, PCancelable.CancelError);
+	await t.throwsAsync(elCheck, PCancelable.CancelError);
 });
 
 test('ensure different promises are returned on second call with the same selector when first was canceled', async t => {
@@ -101,7 +101,7 @@ test('ensure different promises are returned on second call with the same select
 
 	const elCheck2 = m('.unicorn');
 
-	await t.throws(elCheck1, PCancelable.CancelError);
+	await t.throwsAsync(elCheck1, PCancelable.CancelError);
 	t.not(elCheck1, elCheck2);
 });
 


### PR DESCRIPTION
~~This comes after #15 because both fix currently-breaking tests.~~

I'm sending this because [`many-keys-map`](https://github.com/bfred-it/many-keys-map) was born from https://github.com/sindresorhus/element-ready/pull/11#issuecomment-351401489

If it's not an improvement, no feelings will be hurt by not merging it.

Note: it doesn't use `WeakMap` anymore, but `element-ready` already cleans the map when it finds it or it's cancelled. If it's never cancelled, it means that there's a function running up to 60 times a second forever—arguably more detrimental to performance than an object in memory.