### PR TITLE
Add `stopOnDomReady` option, remove `.cancel()`, add `.stop()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,13 +33,13 @@ import elementReady = require('element-ready');
 declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): PCancelable<HTMLElementTagNameMap[ElementName]?>;
+): PCancelable<HTMLElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): PCancelable<SVGElementTagNameMap[ElementName]?>;
+): PCancelable<SVGElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: elementReady.Options
-): PCancelable<ElementName?>;
+): PCancelable<ElementName | undefined>;
 export = elementReady;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace elementReady {
 		readonly target?: Element | Document;
 	}
 
-	type PStoppable<T> = Promise<T> & {
+	type StoppablePromise<T> = Promise<T> & {
 		stop(): void;
 	}
 }
@@ -36,13 +36,13 @@ import elementReady = require('element-ready');
 declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): elementReady.PStoppable<HTMLElementTagNameMap[ElementName] | undefined>;
+): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): elementReady.PStoppable<SVGElementTagNameMap[ElementName] | undefined>;
+): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: elementReady.Options
-): elementReady.PStoppable<ElementName | undefined>;
+): elementReady.StoppablePromise<ElementName | undefined>;
 export = elementReady;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference lib="dom"/>
-import PCancelable = require('p-cancelable');
 
 declare namespace elementReady {
 	interface Options {
@@ -9,6 +8,10 @@ declare namespace elementReady {
 		@default document
 		*/
 		readonly target?: Element | Document;
+	}
+
+	type PStoppable<T> = Promise<T> & {
+		stop(): void;
 	}
 }
 
@@ -33,13 +36,13 @@ import elementReady = require('element-ready');
 declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): PCancelable<HTMLElementTagNameMap[ElementName] | undefined>;
+): elementReady.PStoppable<HTMLElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
-): PCancelable<SVGElementTagNameMap[ElementName] | undefined>;
+): elementReady.PStoppable<SVGElementTagNameMap[ElementName] | undefined>;
 declare function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: elementReady.Options
-): PCancelable<ElementName | undefined>;
+): elementReady.PStoppable<ElementName | undefined>;
 export = elementReady;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,14 +20,14 @@ export default function elementReady<
 >(
 	selector: ElementName,
 	options?: Options
-): PCancelable<HTMLElementTagNameMap[ElementName]>;
+): PCancelable<HTMLElementTagNameMap[ElementName] | null>;
 export default function elementReady<
 	ElementName extends keyof SVGElementTagNameMap
 >(
 	selector: ElementName,
 	options?: Options
-): PCancelable<SVGElementTagNameMap[ElementName]>;
+): PCancelable<SVGElementTagNameMap[ElementName] | null>;
 export default function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: Options
-): PCancelable<ElementName>;
+): PCancelable<ElementName | null>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,14 +20,14 @@ export default function elementReady<
 >(
 	selector: ElementName,
 	options?: Options
-): PCancelable<HTMLElementTagNameMap[ElementName] | null>;
+): PCancelable<HTMLElementTagNameMap[ElementName]?>;
 export default function elementReady<
 	ElementName extends keyof SVGElementTagNameMap
 >(
 	selector: ElementName,
 	options?: Options
-): PCancelable<SVGElementTagNameMap[ElementName] | null>;
+): PCancelable<SVGElementTagNameMap[ElementName]?>;
 export default function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: Options
-): PCancelable<ElementName | null>;
+): PCancelable<ElementName?>;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const cache = new ManyKeysMap();
 const elementReady = (selector, options) => {
 	const {target, cancelOnDomLoaded} = {
 		target: document,
-			cancelOnDomLoaded: true,
+		cancelOnDomLoaded: true,
 		...options
 	};
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const domLoaded = require('dom-loaded');
 const pDefer = require('p-defer');
 
 const cache = new ManyKeysMap();
-const elementReady = (selector, options) => {
+const elementReady = (selector, options = {}) => {
 	const {
 		target = document,
 		stopOnDomReady = true

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const domLoaded = require('dom-loaded');
 const cache = new ManyKeysMap();
 
 const elementReady = (selector, options) => {
-	const {target, until} = Object.assign({
+	const {target, cancelOnDomLoaded} = Object.assign({
 		target: document,
-		until: domLoaded
+		cancelOnDomLoaded: true
 	}, options);
 
-	const cacheKeys = [target, selector, until];
+	const cacheKeys = [target, selector, cancelOnDomLoaded];
 	let promise = cache.get(cacheKeys);
 	if (promise) {
 		return promise;
@@ -25,8 +25,8 @@ const elementReady = (selector, options) => {
 			cache.delete(cacheKeys, promise);
 		});
 
-		if (until && typeof until.then === 'function') {
-			until.then(() => {
+		if (cancelOnDomLoaded) {
+			domLoaded.then(() => {
 				cancelAnimationFrame(rafId);
 				resolve(null);
 			});

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ const domLoaded = require('dom-loaded');
 const cache = new ManyKeysMap();
 
 const elementReady = (selector, options) => {
-	const {target, cancelOnDomLoaded} = {
+	const {target, stopOnDomReady} = {
 		target: document,
-		cancelOnDomLoaded: true,
+		stopOnDomReady: true,
 		...options
 	};
 
-	const cacheKeys = [target, selector, cancelOnDomLoaded];
+	const cacheKeys = [target, selector, stopOnDomReady];
 	let promise = cache.get(cacheKeys);
 	if (promise) {
 		return promise;
@@ -26,7 +26,7 @@ const elementReady = (selector, options) => {
 			cache.delete(cacheKeys, promise);
 		});
 
-		if (cancelOnDomLoaded) {
+		if (stopOnDomReady) {
 			domLoaded.then(() => {
 				cancelAnimationFrame(rafId);
 				resolve();

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const elementReady = (selector, options) => {
 		if (cancelOnDomLoaded) {
 			domLoaded.then(() => {
 				cancelAnimationFrame(rafId);
-				resolve(null);
+				resolve();
 			});
 		}
 

--- a/index.js
+++ b/index.js
@@ -5,24 +5,22 @@ const pDefer = require('p-defer');
 
 const cache = new ManyKeysMap();
 const elementReady = (selector, options) => {
-	const {target, stopOnDomReady} = {
-		target: document,
-		stopOnDomReady: true,
-		...options
-	};
+	const {
+		target = document,
+		stopOnDomReady = true
+	} = options;
 
 	const cacheKeys = [target, selector, stopOnDomReady];
 	const cachedPromise = cache.get(cacheKeys);
-
 	if (cachedPromise) {
 		return cachedPromise;
 	}
 
-	let alreadyFound = false;
 	let rafId;
-
 	const deferred = pDefer();
 	const {promise} = deferred;
+
+	cache.set(cacheKeys, promise);
 
 	const stop = () => {
 		cancelAnimationFrame(rafId);
@@ -40,16 +38,11 @@ const elementReady = (selector, options) => {
 
 		if (el) {
 			deferred.resolve(el);
-			alreadyFound = true;
 			stop();
 		} else {
 			rafId = requestAnimationFrame(check);
 		}
 	})();
-
-	if (!alreadyFound) {
-		cache.set(cacheKeys, promise);
-	}
 
 	return Object.assign(promise, {stop});
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,6 +6,7 @@ const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 
+expectType<PCancelable<null>>(promise);
 expectType<PCancelable<Element>>(promise);
 expectType<PCancelable<HTMLDivElement>>(elementReady('div'));
 expectType<PCancelable<SVGElement>>(elementReady('text'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 
 expectType<PCancelable<Element | undefined>>(promise);
-expectType<PCancelable<HTMLDivElement>>(elementReady('div'));
-expectType<PCancelable<SVGElement>>(elementReady('text'));
+expectType<PCancelable<HTMLDivElement | undefined>>(elementReady('div'));
+expectType<PCancelable<SVGElement | undefined>>(elementReady('text'));
 
 promise.cancel();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,13 +1,12 @@
 import {expectType} from 'tsd';
-import PCancelable = require('p-cancelable');
 import elementReady = require('.');
 
 const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 
-expectType<PCancelable<Element | undefined>>(promise);
-expectType<PCancelable<HTMLDivElement | undefined>>(elementReady('div'));
-expectType<PCancelable<SVGElement | undefined>>(elementReady('text'));
+expectType<elementReady.PStoppable<Element | undefined>>(promise);
+expectType<elementReady.PStoppable<HTMLDivElement | undefined>>(elementReady('div'));
+expectType<elementReady.PStoppable<SVGElement | undefined>>(elementReady('text'));
 
-promise.cancel();
+promise.stop();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,8 +6,7 @@ const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 
-expectType<PCancelable<null>>(promise);
-expectType<PCancelable<Element>>(promise);
+expectType<PCancelable<Element | undefined>>(promise);
 expectType<PCancelable<HTMLDivElement>>(elementReady('div'));
 expectType<PCancelable<SVGElement>>(elementReady('text'));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,8 +5,8 @@ const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 
-expectType<elementReady.PStoppable<Element | undefined>>(promise);
-expectType<elementReady.PStoppable<HTMLDivElement | undefined>>(elementReady('div'));
-expectType<elementReady.PStoppable<SVGElement | undefined>>(elementReady('text'));
+expectType<elementReady.StoppablePromise<Element | undefined>>(promise);
+expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementReady('div'));
+expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
 promise.stop();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"dom-loaded": "^1.1.0",
 		"many-keys-map": "^1.0.1",
-		"p-cancelable": "^2.0.0"
+		"p-defer": "^2.1.0"
 	},
 	"devDependencies": {
 		"ava": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"check"
 	],
 	"dependencies": {
+		"dom-loaded": "^1.1.0",
 		"many-keys-map": "^1.0.0",
 		"p-cancelable": "^1.1.0"
 	},

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
 		"envs": [
 			"node",
 			"browser"
-		]
+		],
+		"rules": {
+			"promise/prefer-await-to-then": 0
+		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -54,15 +54,13 @@ Default: `true`
 
 Automatically stops checking for the element to be ready after the DOM ready event.
 
-### elementReadyPromise#cancel()
+### elementReadyPromise#stop()
 
 Type: `Function`
 
-Stops checking for the element to be ready. The cancelation is synchronous.
+Stops checking for the element to be ready. The stop is synchronous.
 
 Calling it after the promise has settled or multiple times does nothing.
-
-Based on [p-cancelable](https://github.com/sindresorhus/p-cancelable).
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -38,11 +38,11 @@ Type: `string`
 
 #### options
 
-Type: `Object`
+Type: `object`
 
 ##### target
 
-Type: `Element` `document`<br>
+Type: `Element | document`<br>
 Default: `document`
 
 The element that's expected to contain a match.
@@ -52,13 +52,13 @@ The element that's expected to contain a match.
 Type: `boolean`<br>
 Default: `true`
 
-Automatically stops checking for the element to be ready after the DOM ready event.
+Automatically stops checking for the element to be ready after the DOM ready event and the promise is resolved to `undefined`.
 
 ### elementReadyPromise#stop()
 
-Type: `Function`
+Type: `function`
 
-Stops checking for the element to be ready. The stop is synchronous.
+Stops checking for the element to be ready. The stop is synchronous and the original promise is resolved to `undefined`.
 
 Calling it after the promise has settled or multiple times does nothing.
 

--- a/readme.md
+++ b/readme.md
@@ -52,13 +52,13 @@ The element that's expected to contain a match.
 Type: `boolean`<br>
 Default: `true`
 
-Automatically stops checking for the element to be ready after the DOM ready event and the promise is resolved to `undefined`.
+Automatically stop checking for the element to be ready after the [DOM ready event](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event). The promise is then resolved to `undefined`.
 
 ### elementReadyPromise#stop()
 
 Type: `Function`
 
-Stops checking for the element to be ready. The stop is synchronous and the original promise is resolved to `undefined`.
+Stop checking for the element to be ready. The stop is synchronous and the original promise is then resolved to `undefined`.
 
 Calling it after the promise has settled or multiple times does nothing.
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Automatically stops checking for the element to be ready after the DOM ready eve
 
 ### elementReadyPromise#stop()
 
-Type: `function`
+Type: `Function`
 
 Stops checking for the element to be ready. The stop is synchronous and the original promise is resolved to `undefined`.
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,13 @@ Default: `document`
 
 The element that's expected to contain a match.
 
+##### cancelOnDomLoaded
+
+Type: `boolean`<br>
+Default: `true`
+
+Automatically stops checking for the element to be ready after the DOM ready event.
+
 ### elementReadyPromise#cancel()
 
 Type: `Function`

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Default: `document`
 
 The element that's expected to contain a match.
 
-##### cancelOnDomLoaded
+##### stopOnDomReady
 
 Type: `boolean`<br>
 Default: `true`

--- a/test.js
+++ b/test.js
@@ -85,7 +85,7 @@ test('check if element ready after dom loaded', async t => {
 	});
 
 	const element = await elementCheck;
-	t.is(element, null);
+	t.is(element, undefined);
 });
 
 test('check if element ready before dom loaded', async t => {

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ global.cancelAnimationFrame = id => clearTimeout(id);
 const elementReady = require('.');
 
 test('check if element ready', async t => {
-	const elementCheck = elementReady('#unicorn', {until: false});
+	const elementCheck = elementReady('#unicorn', {cancelOnDomLoaded: false});
 
 	delay(500).then(() => {
 		const element = document.createElement('p');
@@ -29,7 +29,7 @@ test('check if element ready inside target', async t => {
 	const target = document.createElement('p');
 	const elCheck = elementReady('#unicorn', {
 		target,
-		until: false
+		cancelOnDomLoaded: false
 	});
 
 	delay(500).then(() => {
@@ -46,12 +46,12 @@ test('check if different elements ready inside different targets with same selec
 	const target1 = document.createElement('p');
 	const elementCheck1 = elementReady('.unicorn', {
 		target: target1,
-		until: false
+		cancelOnDomLoaded: false
 	});
 	const target2 = document.createElement('span');
 	const elementCheck2 = elementReady('.unicorn', {
 		target: target2,
-		until: false
+		cancelOnDomLoaded: false
 	});
 
 	delay(500).then(() => {
@@ -73,11 +73,38 @@ test('check if different elements ready inside different targets with same selec
 	t.is(element2.id, 'unicorn2');
 });
 
+test('check if element ready after dom loaded', async t => {
+	const elementCheck = elementReady('#bio', {
+		cancelOnDomLoaded: true
+	});
+
+	delay(50000).then(() => {
+		const element = document.createElement('p');
+		element.id = 'bio';
+		document.body.append(element);
+	});
+
+	const element = await elementCheck;
+	t.is(element, null);
+});
+
+test('check if element ready before dom loaded', async t => {
+	const element = document.createElement('p');
+	element.id = 'history';
+	document.body.append(element);
+
+	const elementCheck = elementReady('#history', {
+		cancelOnDomLoaded: true
+	});
+
+	t.is(await elementCheck, element);
+});
+
 test('ensure only one promise is returned on multiple calls passing the same selector', t => {
-	const elementCheck = elementReady('#wait', {until: false});
+	const elementCheck = elementReady('#wait', {cancelOnDomLoaded: false});
 
 	for (let i = 0; i <= 10; i++) {
-		if (elementReady('#wait', {until: false}) !== elementCheck) {
+		if (elementReady('#wait', {cancelOnDomLoaded: false}) !== elementCheck) {
 			t.fail();
 		}
 	}
@@ -86,7 +113,7 @@ test('ensure only one promise is returned on multiple calls passing the same sel
 });
 
 test('check if wait can be canceled', async t => {
-	const elementCheck = elementReady('#dofle', {until: false});
+	const elementCheck = elementReady('#dofle', {cancelOnDomLoaded: false});
 
 	await delay(200);
 	elementCheck.cancel();
@@ -100,11 +127,11 @@ test('check if wait can be canceled', async t => {
 });
 
 test('ensure different promises are returned on second call with the same selector when first was canceled', async t => {
-	const elementCheck1 = elementReady('.unicorn', {until: false});
+	const elementCheck1 = elementReady('.unicorn', {cancelOnDomLoaded: false});
 
 	elementCheck1.cancel();
 
-	const elementCheck2 = elementReady('.unicorn', {until: false});
+	const elementCheck2 = elementReady('.unicorn', {cancelOnDomLoaded: false});
 
 	await t.throwsAsync(elementCheck1, PCancelable.CancelError);
 	t.not(elementCheck1, elementCheck2);

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 import test from 'ava';
 import {JSDOM} from 'jsdom';
 import delay from 'delay';
-import PCancelable from 'p-cancelable';
 
 const {window} = new JSDOM();
 global.window = window;
@@ -105,10 +104,10 @@ test('check if element ready before dom loaded', async t => {
 });
 
 test('ensure only one promise is returned on multiple calls passing the same selector', t => {
-	const elementCheck = elementReady('#wait', {stopOnDomReady: false});
+	const elementCheck = elementReady('#not-found', {stopOnDomReady: false});
 
 	for (let i = 0; i <= 10; i++) {
-		if (elementReady('#wait', {stopOnDomReady: false}) !== elementCheck) {
+		if (elementReady('#not-found', {stopOnDomReady: false}) !== elementCheck) {
 			t.fail();
 		}
 	}
@@ -116,28 +115,29 @@ test('ensure only one promise is returned on multiple calls passing the same sel
 	t.pass();
 });
 
-test('check if wait can be canceled', async t => {
+test('check if wait can be stopped', async t => {
 	const elementCheck = elementReady('#dofle', {stopOnDomReady: false});
 
 	await delay(200);
-	elementCheck.cancel();
+	elementCheck.stop();
 
 	await delay(500);
 	const element = document.createElement('p');
 	element.id = 'dofle';
 	document.body.append(element);
 
-	await t.throwsAsync(elementCheck, PCancelable.CancelError);
+	t.is(await elementCheck, undefined);
 });
 
-test('ensure different promises are returned on second call with the same selector when first was canceled', async t => {
+test('ensure different promises are returned on second call with the same selector when first was stopped', async t => {
 	const elementCheck1 = elementReady('.unicorn', {stopOnDomReady: false});
 
-	elementCheck1.cancel();
+	elementCheck1.stop();
 
 	const elementCheck2 = elementReady('.unicorn', {stopOnDomReady: false});
 
-	await t.throwsAsync(elementCheck1, PCancelable.CancelError);
+	t.is(await elementCheck1, undefined);
+
 	t.not(elementCheck1, elementCheck2);
 });
 

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ global.cancelAnimationFrame = id => clearTimeout(id);
 const elementReady = require('.');
 
 test('check if element ready', async t => {
-	const elementCheck = elementReady('#unicorn', {cancelOnDomLoaded: false});
+	const elementCheck = elementReady('#unicorn', {stopOnDomReady: false});
 
 	(async () => {
 		await delay(500);
@@ -30,7 +30,7 @@ test('check if element ready inside target', async t => {
 	const target = document.createElement('p');
 	const elCheck = elementReady('#unicorn', {
 		target,
-		cancelOnDomLoaded: false
+		stopOnDomReady: false
 	});
 
 	(async () => {
@@ -48,12 +48,12 @@ test('check if different elements ready inside different targets with same selec
 	const target1 = document.createElement('p');
 	const elementCheck1 = elementReady('.unicorn', {
 		target: target1,
-		cancelOnDomLoaded: false
+		stopOnDomReady: false
 	});
 	const target2 = document.createElement('span');
 	const elementCheck2 = elementReady('.unicorn', {
 		target: target2,
-		cancelOnDomLoaded: false
+		stopOnDomReady: false
 	});
 
 	(async () => {
@@ -78,7 +78,7 @@ test('check if different elements ready inside different targets with same selec
 
 test('check if element ready after dom loaded', async t => {
 	const elementCheck = elementReady('#bio', {
-		cancelOnDomLoaded: true
+		stopOnDomReady: true
 	});
 
 	// The element will be added eventually, but we're not around to wait for it
@@ -98,17 +98,17 @@ test('check if element ready before dom loaded', async t => {
 	document.body.append(element);
 
 	const elementCheck = elementReady('#history', {
-		cancelOnDomLoaded: true
+		stopOnDomReady: true
 	});
 
 	t.is(await elementCheck, element);
 });
 
 test('ensure only one promise is returned on multiple calls passing the same selector', t => {
-	const elementCheck = elementReady('#wait', {cancelOnDomLoaded: false});
+	const elementCheck = elementReady('#wait', {stopOnDomReady: false});
 
 	for (let i = 0; i <= 10; i++) {
-		if (elementReady('#wait', {cancelOnDomLoaded: false}) !== elementCheck) {
+		if (elementReady('#wait', {stopOnDomReady: false}) !== elementCheck) {
 			t.fail();
 		}
 	}
@@ -117,7 +117,7 @@ test('ensure only one promise is returned on multiple calls passing the same sel
 });
 
 test('check if wait can be canceled', async t => {
-	const elementCheck = elementReady('#dofle', {cancelOnDomLoaded: false});
+	const elementCheck = elementReady('#dofle', {stopOnDomReady: false});
 
 	await delay(200);
 	elementCheck.cancel();
@@ -131,11 +131,11 @@ test('check if wait can be canceled', async t => {
 });
 
 test('ensure different promises are returned on second call with the same selector when first was canceled', async t => {
-	const elementCheck1 = elementReady('.unicorn', {cancelOnDomLoaded: false});
+	const elementCheck1 = elementReady('.unicorn', {stopOnDomReady: false});
 
 	elementCheck1.cancel();
 
-	const elementCheck2 = elementReady('.unicorn', {cancelOnDomLoaded: false});
+	const elementCheck2 = elementReady('.unicorn', {stopOnDomReady: false});
 
 	await t.throwsAsync(elementCheck1, PCancelable.CancelError);
 	t.not(elementCheck1, elementCheck2);

--- a/test.js
+++ b/test.js
@@ -81,11 +81,12 @@ test('check if element ready after dom loaded', async t => {
 		cancelOnDomLoaded: true
 	});
 
-	delay(50000).then(() => {
+	// The element will be added eventually, but we're not around to wait for it
+	setTimeout(() => {
 		const element = document.createElement('p');
 		element.id = 'bio';
 		document.body.append(element);
-	});
+	}, 50000);
 
 	const element = await elementCheck;
 	t.is(element, undefined);


### PR DESCRIPTION
Requires semver major because it changes the default behavior.

- [x] Approval
- [x] `index.test-d.ts` with `null`, why is it failing?
- [x] Docs

Fixes #8 