### PR TITLE
Correct the return type when timeout is undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,10 @@ declare namespace elementReady {
 		readonly stopOnDomReady?: boolean;
 	}
 
+	interface OptionsWithInfiniteTimeout extends Options {
+		readonly timeout: undefined;
+	}
+
 	type StoppablePromise<T> = Promise<T> & {
 		/**
 		Stop checking for the element to be ready. The stop is synchronous and the original promise is then resolved to `undefined`.
@@ -54,14 +58,29 @@ import elementReady = require('element-ready');
 */
 declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
 	selector: ElementName,
+	options?: elementReady.OptionsWithInfiniteTimeout
+): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | never>;
+declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
+	selector: ElementName,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | undefined>;
+
+declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
+	selector: ElementName,
+	options?: elementReady.OptionsWithInfiniteTimeout
+): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | never>;
 declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | undefined>;
+
+declare function elementReady<ElementName extends Element = Element>(
+	selector: string,
+	options?: elementReady.OptionsWithInfiniteTimeout
+): elementReady.StoppablePromise<ElementName | never>;
 declare function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<ElementName | undefined>;
+
 export = elementReady;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,15 +1,17 @@
 import {expectType} from 'tsd';
 import elementReady = require('.');
 
-const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 elementReady('#unicorn', {timeout: 1000000});
 
 elementReady('#unicorn', {stopOnDomReady: false});
 
-expectType<elementReady.StoppablePromise<Element | undefined>>(promise);
-expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementReady('div'));
-expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
+expectType<elementReady.StoppablePromise<Element | never>>(elementReady('#unicorn'));
+expectType<elementReady.StoppablePromise<Element | undefined>>(elementReady('#unicorn', {timeout: 100}));
 
-promise.stop();
+expectType<elementReady.StoppablePromise<HTMLDivElement | never>>(elementReady('div'));
+expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementReady('div', {timeout: 100}));
+
+expectType<elementReady.StoppablePromise<SVGElement | never>>(elementReady('text'));
+expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text', {timeout: 100}));


### PR DESCRIPTION
I’m opening this PR to discuss potential definition improvements.

**When called without timeout specified, the `elementReady()` should have the return type of `Element | never` since the promise is either resolved with given element or doesn’t resolve at all.**

…But, while creating this PR I realized the assumptions above are wrong. 😅

The `stopOnDomReady` option and the `stop()` function added to the Promise make it so that resolved value can be `undefined` anyway. While I can also match `stopOnDomReady: false`, the `stop()` function throws a wrench in my original idea…

---

This PR added definitions that handle the `timeout = undefined` case (I don’t think it’s possible to support the explicit version: `timeout = Infinity`, but I’d love to be proven wrong).

(the issue originally mentioned in https://github.com/sindresorhus/caprine/pull/923#discussion_r298812875)

---

Anyway, save for adding another option that would explicitly indicate that the returned Promise is not cancellable, I don’t see any other way to make this work. Ideas? 😛