### PR TITLE
Add `elementReady.subscribe()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,15 @@ declare namespace elementReady {
 		readonly stopOnDomReady?: boolean;
 	}
 
+  type Stoppable = {
+    /**
+     Stop checking for new elements.
+
+     Calling it multiple times does nothing.
+     */
+    stop(): void;
+  };
+
 	type StoppablePromise<T> = Promise<T> & {
 		/**
 		Stop checking for the element to be ready. The stop is synchronous and the original promise is then resolved to `undefined`.
@@ -57,19 +66,19 @@ declare namespace elementReady {
     selector: ElementName,
     cb: elementReady.SubscribeCallback<HTMLElementTagNameMap[ElementName]>,
     options?: elementReady.Options
-  ): () => void;
+  ): Stoppable;
 
   function subscribe<ElementName extends keyof SVGElementTagNameMap>(
     selector: ElementName,
     cb: elementReady.SubscribeCallback<SVGElementTagNameMap[ElementName]>,
     options?: elementReady.Options
-  ): () => void;
+  ): Stoppable;
 
   function subscribe<ElementName extends Element = Element>(
     selector: string,
     cb: elementReady.SubscribeCallback<ElementName>,
     options?: elementReady.Options
-  ): () => void;
+  ): Stoppable;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,30 +24,6 @@ declare namespace elementReady {
 		readonly stopOnDomReady?: boolean;
 	}
 
-	interface SubscribeOptions {
-		/**
-		The element that's expected to contain a match.
-
-		@default document
-		*/
-		readonly target?: Element | Document;
-
-		/**
-		Milliseconds to wait before stopping the search.
-
-		@default Infinity
-		*/
-		readonly timeout?: number
-
-		/**
-		Automatically stop searching for new elements after the DOM ready event.
-		If this is true, and `subscribe` function is being called after the DOM ready event, it just detects the elements that are currently in the DOM and then stops searching for new elements immediately.
-
-		@default false
-		*/
-		readonly stopOnDomReady?: boolean;
-	}
-
 	type Stoppable = {
 		/**
 		Stop checking for new elements.
@@ -89,19 +65,19 @@ declare namespace elementReady {
   function subscribe<ElementName extends keyof HTMLElementTagNameMap>(
     selector: ElementName,
     callback: elementReady.SubscribeCallback<HTMLElementTagNameMap[ElementName]>,
-    options?: elementReady.SubscribeOptions
+    options?: elementReady.Options
   ): Stoppable;
 
   function subscribe<ElementName extends keyof SVGElementTagNameMap>(
     selector: ElementName,
     callback: elementReady.SubscribeCallback<SVGElementTagNameMap[ElementName]>,
-    options?: elementReady.SubscribeOptions
+    options?: elementReady.Options
   ): Stoppable;
 
   function subscribe<ElementName extends Element = Element>(
     selector: string,
     callback: elementReady.SubscribeCallback<ElementName>,
-    options?: elementReady.SubscribeOptions
+    options?: elementReady.Options
   ): Stoppable;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,14 +24,14 @@ declare namespace elementReady {
 		readonly stopOnDomReady?: boolean;
 	}
 
-  type Stoppable = {
-    /**
-     Stop checking for new elements.
+	type Stoppable = {
+		/**
+		 Stop checking for new elements.
 
-     Calling it multiple times does nothing.
-     */
-    stop(): void;
-  };
+		 Calling it multiple times does nothing.
+		 */
+		stop(): void;
+	};
 
 	type StoppablePromise<T> = Promise<T> & {
 		/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,44 @@ declare namespace elementReady {
 		*/
 		stop(): void;
 	}
+
+  /**
+  Called on each new element that matches the selector in the DOM.
+  */
+  type SubscribeCallback<T> = (el: T) => any;
+
+  /**
+  Detect elements as they are added to the DOM.
+
+  @param selector - [CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
+  @param cb Callback that is called for each new element.
+  @returns The unsubscribe function.
+
+  @example
+  ```
+  import elementReady = require('element-ready');
+  elementReady.subscribe('a', (element) => {
+    console.log(element.id)
+  })
+  ```
+  */
+  function subscribe<ElementName extends keyof HTMLElementTagNameMap>(
+    selector: ElementName,
+    cb: elementReady.SubscribeCallback<HTMLElementTagNameMap[ElementName]>,
+    options?: elementReady.Options
+  ): () => void;
+
+  function subscribe<ElementName extends keyof SVGElementTagNameMap>(
+    selector: ElementName,
+    cb: elementReady.SubscribeCallback<SVGElementTagNameMap[ElementName]>,
+    options?: elementReady.Options
+  ): () => void;
+
+  function subscribe<ElementName extends Element = Element>(
+    selector: string,
+    cb: elementReady.SubscribeCallback<ElementName>,
+    options?: elementReady.Options
+  ): () => void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,12 +24,36 @@ declare namespace elementReady {
 		readonly stopOnDomReady?: boolean;
 	}
 
+	interface SubscribeOptions {
+		/**
+		The element that's expected to contain a match.
+
+		@default document
+		*/
+		readonly target?: Element | Document;
+
+		/**
+		Milliseconds to wait before stopping the search.
+
+		@default Infinity
+		*/
+		readonly timeout?: number
+
+		/**
+		Automatically stop searching for new elements after the DOM ready event.
+		If this is true, and `subscribe` function is being called after the DOM ready event, it just detects the elements that are currently in the DOM and then stops searching for new elements immediately.
+
+		@default false
+		*/
+		readonly stopOnDomReady?: boolean;
+	}
+
 	type Stoppable = {
 		/**
-		 Stop checking for new elements.
+		Stop checking for new elements.
 
-		 Calling it multiple times does nothing.
-		 */
+		Calling it multiple times does nothing.
+		*/
 		stop(): void;
 	};
 
@@ -45,14 +69,14 @@ declare namespace elementReady {
   /**
   Called on each new element that matches the selector in the DOM.
   */
-  type SubscribeCallback<T> = (el: T) => any;
+  type SubscribeCallback<T> = (element: T) => void;
 
   /**
   Detect elements as they are added to the DOM.
 
   @param selector - [CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
-  @param cb Callback that is called for each new element.
-  @returns The unsubscribe function.
+  @param callback - Callback to be called for each new element.
+  @returns A stoppable that can be used to unsubscribe to this event.
 
   @example
   ```
@@ -64,20 +88,20 @@ declare namespace elementReady {
   */
   function subscribe<ElementName extends keyof HTMLElementTagNameMap>(
     selector: ElementName,
-    cb: elementReady.SubscribeCallback<HTMLElementTagNameMap[ElementName]>,
-    options?: elementReady.Options
+    callback: elementReady.SubscribeCallback<HTMLElementTagNameMap[ElementName]>,
+    options?: elementReady.SubscribeOptions
   ): Stoppable;
 
   function subscribe<ElementName extends keyof SVGElementTagNameMap>(
     selector: ElementName,
-    cb: elementReady.SubscribeCallback<SVGElementTagNameMap[ElementName]>,
-    options?: elementReady.Options
+    callback: elementReady.SubscribeCallback<SVGElementTagNameMap[ElementName]>,
+    options?: elementReady.SubscribeOptions
   ): Stoppable;
 
   function subscribe<ElementName extends Element = Element>(
     selector: string,
-    cb: elementReady.SubscribeCallback<ElementName>,
-    options?: elementReady.Options
+    callback: elementReady.SubscribeCallback<ElementName>,
+    options?: elementReady.SubscribeOptions
   ): Stoppable;
 }
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ const elementReady = (selector, {
 
 elementReady.subscribe = (selector, callback, {
 	target = document,
-	stopOnDomReady = false,
+	stopOnDomReady = true,
 	timeout = Infinity
 } = {}) => {
 	const seenElements = new WeakSet();

--- a/index.js
+++ b/index.js
@@ -63,13 +63,6 @@ elementReady.subscribe = (selector, callback, {
 		cancelAnimationFrame(rafId);
 	};
 
-	if (stopOnDomReady) {
-		(async () => {
-			await domLoaded;
-			stop();
-		})();
-	}
-
 	if (timeout !== Infinity) {
 		setTimeout(stop, timeout);
 	}
@@ -88,8 +81,10 @@ elementReady.subscribe = (selector, callback, {
 			}
 		}
 
-		rafId = requestAnimationFrame(check);
-		checkFrame = !checkFrame;
+		if (!(stopOnDomReady && isDomReady())) {
+			rafId = requestAnimationFrame(check);
+			checkFrame = !checkFrame;
+		}
 	})();
 
 	return {stop};

--- a/index.js
+++ b/index.js
@@ -54,12 +54,12 @@ const elementReady = (selector, {
 	return Object.assign(promise, {stop});
 };
 
-elementReady.subscribe = (selector, cb, {
+elementReady.subscribe = (selector, callback, {
 	target = document,
-	stopOnDomReady = true,
+	stopOnDomReady = false,
 	timeout = Infinity
 } = {}) => {
-	const seen = new WeakSet();
+	const seenElements = new WeakSet();
 
 	let rafId;
 	let checkFrame = true;
@@ -83,15 +83,13 @@ elementReady.subscribe = (selector, cb, {
 		if (checkFrame) {
 			const allElements = target.querySelectorAll(selector);
 
-			for (let i = 0; i < allElements.length; ++i) {
-				const element = allElements[i];
-
-				if (seen.has(element)) {
+			for (const element of allElements) {
+				if (seenElements.has(element)) {
 					continue;
 				}
 
-				cb(element);
-				seen.add(element);
+				callback(element);
+				seenElements.add(element);
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ elementReady.subscribe = (selector, cb, {
 	stopOnDomReady = true,
 	timeout = Infinity
 } = {}) => {
-	const seen = new WeakMap();
+	const seen = new WeakSet();
 
 	let rafId;
 	let checkFrame = true;
@@ -91,7 +91,7 @@ elementReady.subscribe = (selector, cb, {
 				}
 
 				cb(element);
-				seen.set(element, true);
+				seen.add(element);
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ elementReady.subscribe = (selector, cb, {
 	const seen = new WeakMap();
 
 	let rafId;
-	let checkNum = 1;
+	let checkFrame = true;
 
 	const stop = () => {
 		cancelAnimationFrame(rafId);
@@ -80,7 +80,7 @@ elementReady.subscribe = (selector, cb, {
 	}
 
 	(function check() {
-		if (checkNum % 2) {
+		if (checkFrame) {
 			const allElements = target.querySelectorAll(selector);
 
 			for (let i = 0; i < allElements.length; ++i) {
@@ -96,10 +96,10 @@ elementReady.subscribe = (selector, cb, {
 		}
 
 		rafId = requestAnimationFrame(check);
-		checkNum += 1;
+		checkFrame = !checkFrame;
 	})();
 
-	return stop;
+	return {stop};
 };
 
 module.exports = elementReady;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,14 +13,20 @@ expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementRea
 expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
 
-const {stop} = elementReady.subscribe('.unicorn', e => null);
-elementReady.subscribe('.unicorn', e => null, {target: document});
-elementReady.subscribe('.unicorn', e => null, {target: document.documentElement});
-elementReady.subscribe('.unicorn', e => null, {stopOnDomReady: false});
+const {stop} = elementReady.subscribe('.unicorn', element => null);
+elementReady.subscribe('.unicorn', element => null, {target: document});
+elementReady.subscribe('.unicorn', element => null, {target: document.documentElement});
+elementReady.subscribe('.unicorn', element => null, {stopOnDomReady: false});
 
-elementReady.subscribe('.unicorn', e => expectType<Element>(e));
-elementReady.subscribe('div', e => expectType<HTMLDivElement>(e));
-elementReady.subscribe('text', e => expectType<SVGElement>(e));
+elementReady.subscribe('.unicorn', element => {
+	expectType<Element>(element);
+});
+elementReady.subscribe('div', element => {
+	expectType<HTMLDivElement>(element);
+});
+elementReady.subscribe('text', element => {
+	expectType<SVGElement>(element)
+});
 
 expectType<() => any>(stop);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,7 +13,7 @@ expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementRea
 expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
 
-const stop = elementReady.subscribe(".unicorn", e => null);
+const {stop} = elementReady.subscribe(".unicorn", e => null);
 elementReady.subscribe(".unicorn", e => null, {target: document});
 elementReady.subscribe(".unicorn", e => null, {target: document.documentElement});
 elementReady.subscribe(".unicorn", e => null, {stopOnDomReady: false});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,4 +12,17 @@ expectType<elementReady.StoppablePromise<Element | undefined>>(promise);
 expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementReady('div'));
 expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
+
+const stop = elementReady.subscribe(".unicorn", e => null);
+elementReady.subscribe(".unicorn", e => null, {target: document});
+elementReady.subscribe(".unicorn", e => null, {target: document.documentElement});
+elementReady.subscribe(".unicorn", e => null, {stopOnDomReady: false});
+
+elementReady.subscribe(".unicorn", e => expectType<Element>(e));
+elementReady.subscribe("div", e => expectType<HTMLDivElement>(e));
+elementReady.subscribe("text", e => expectType<SVGElement>(e));
+
+expectType<() => any>(stop);
+
 promise.stop();
+stop();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,14 +13,14 @@ expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementRea
 expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
 
-const {stop} = elementReady.subscribe(".unicorn", e => null);
-elementReady.subscribe(".unicorn", e => null, {target: document});
-elementReady.subscribe(".unicorn", e => null, {target: document.documentElement});
-elementReady.subscribe(".unicorn", e => null, {stopOnDomReady: false});
+const {stop} = elementReady.subscribe('.unicorn', e => null);
+elementReady.subscribe('.unicorn', e => null, {target: document});
+elementReady.subscribe('.unicorn', e => null, {target: document.documentElement});
+elementReady.subscribe('.unicorn', e => null, {stopOnDomReady: false});
 
-elementReady.subscribe(".unicorn", e => expectType<Element>(e));
-elementReady.subscribe("div", e => expectType<HTMLDivElement>(e));
-elementReady.subscribe("text", e => expectType<SVGElement>(e));
+elementReady.subscribe('.unicorn', e => expectType<Element>(e));
+elementReady.subscribe('div', e => expectType<HTMLDivElement>(e));
+elementReady.subscribe('text', e => expectType<SVGElement>(e));
 
 expectType<() => any>(stop);
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,28 @@ Stop checking for the element to be ready. The stop is synchronous and the origi
 
 Calling it after the promise has settled or multiple times does nothing.
 
+### elementReady.subscribe(selector, cb, options?)
+
+Detect elements as they are added to the DOM.
+
+Returns a function to cancel subscription.
+
+#### selector
+
+Type: `string`
+
+[CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
+
+#### cb
+
+Type: `Function`<br>
+Signature: `(element: Element) => any`
+
+Callback function to be called on each of the discovered elements.
+
+#### options
+
+Same as `elementReady` options.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,11 @@ const elementReady = require('element-ready');
 
 	console.log(element.id);
 	//=> 'unicorn'
+
+	elementReady.subscribe('.rainbow', element => {
+		console.log(element.classList);
+		//=> ['rainbow',...]
+	});
 })();
 ```
 
@@ -69,7 +74,9 @@ Stop checking for the element to be ready. The stop is synchronous and the origi
 
 Calling it after the promise has settled or multiple times does nothing.
 
-### elementReady.subscribe(selector, cb, options?)
+<hr>
+
+### elementReady.subscribe(selector, callback, options?)
 
 Detect elements as they are added to the DOM.
 
@@ -81,18 +88,39 @@ Type: `string`
 
 [CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
 
-#### cb
+#### callback
 
 Type: `Function`<br>
-Signature: `(element: Element) => any`
+Signature: `(element: Element) => void`
 
-Callback function to be called on each of the discovered elements.
+Callback function to be called on each one of the discovered elements.
 
 #### options
 
-Same as `elementReady` options.
+##### target
 
-#### elementReady.subscribe()#stop()
+Type: `Element | document`<br>
+Default: `document`
+
+The element that's expected to contain a match.
+
+##### stopOnDomReady
+
+Type: `boolean`<br>
+Default: `false`
+
+Automatically stop searching for new elements after the [DOM ready event](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event).
+
+If this is true, and `subscribe` function is being called after the DOM ready event, it just detects the elements that are currently in the DOM and then stops searching for new elements immediately.
+
+##### timeout
+
+Type: `number`<br>
+Default: `Infinity`
+
+Milliseconds to wait before stopping the search.
+
+#### stoppable#stop()
 
 Type: `Function`
 

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Calling it after the promise has settled or multiple times does nothing.
 
 Detect elements as they are added to the DOM.
 
-Returns a function to cancel subscription.
+Returns a stoppable to cancel subscription.
 
 #### selector
 
@@ -91,6 +91,14 @@ Callback function to be called on each of the discovered elements.
 #### options
 
 Same as `elementReady` options.
+
+#### elementReady.subscribe()#stop()
+
+Type: `Function`
+
+Stop checking for new elements.
+
+Calling it multiple times does nothing.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ The element that's expected to contain a match.
 ##### stopOnDomReady
 
 Type: `boolean`<br>
-Default: `false`
+Default: `true`
 
 Automatically stop searching for new elements after the [DOM ready event](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event).
 
@@ -120,7 +120,7 @@ Default: `Infinity`
 
 Milliseconds to wait before stopping the search.
 
-#### stoppable#stop()
+### stoppable#stop()
 
 Type: `Function`
 

--- a/test.js
+++ b/test.js
@@ -232,7 +232,7 @@ test('subscribe: stop should work', async t => {
 		document.body.append(elements[2]);
 	})();
 
-	const stop = elementReady.subscribe('.happy-unicorn', el => seen.push(el), {stopOnDomReady: false});
+	const {stop} = elementReady.subscribe('.happy-unicorn', el => seen.push(el), {stopOnDomReady: false});
 	await delay(100);
 	stop();
 	await delay(300);

--- a/test.js
+++ b/test.js
@@ -232,7 +232,7 @@ test('subscribe: stop should work', async t => {
 		document.body.append(elements[2]);
 	})();
 
-	const {stop} = elementReady.subscribe('.happy-unicorn', el => seen.push(el));
+	const {stop} = elementReady.subscribe('.happy-unicorn', el => seen.push(el), {stopOnDomReady: false});
 	await delay(100);
 	stop();
 	await delay(300);

--- a/test.js
+++ b/test.js
@@ -189,13 +189,13 @@ test('ensure different promises are returned on second call with the same select
 });
 
 test('subscribe: check if elements are detected', async t => {
-	const e = () => {
+	const createElement = () => {
 		const element = document.createElement('p');
 		element.className = 'rainbow';
 		return element;
 	};
 
-	const elements = [e(), e(), e()];
+	const elements = [createElement(), createElement(), createElement()];
 	const seen = [];
 
 	(async () => {
@@ -215,13 +215,13 @@ test('subscribe: check if elements are detected', async t => {
 });
 
 test('subscribe: stop should work', async t => {
-	const e = () => {
+	const createElement = () => {
 		const element = document.createElement('p');
 		element.className = 'happy-unicorn';
 		return element;
 	};
 
-	const elements = [e(), e(), e()];
+	const elements = [createElement(), createElement(), createElement()];
 	const seen = [];
 
 	(async () => {
@@ -232,7 +232,7 @@ test('subscribe: stop should work', async t => {
 		document.body.append(elements[2]);
 	})();
 
-	const {stop} = elementReady.subscribe('.happy-unicorn', el => seen.push(el), {stopOnDomReady: false});
+	const {stop} = elementReady.subscribe('.happy-unicorn', el => seen.push(el));
 	await delay(100);
 	stop();
 	await delay(300);

--- a/test.js
+++ b/test.js
@@ -187,3 +187,56 @@ test('ensure different promises are returned on second call with the same select
 	document.querySelector('.unicorn').remove();
 	t.is(prependElement(), await elementReady('.unicorn'));
 });
+
+test('subscribe: check if elements are detected', async t => {
+	const e = () => {
+		const element = document.createElement('p');
+		element.className = 'rainbow';
+		return element;
+	};
+
+	const elements = [e(), e(), e()];
+	const seen = [];
+
+	(async () => {
+		document.body.append(elements[0]);
+		await delay(200);
+		document.body.append(elements[1]);
+		await delay(100);
+		document.body.append(elements[2]);
+	})();
+
+	elementReady.subscribe('.rainbow', el => seen.push(el), {stopOnDomReady: false});
+	await delay(400);
+
+	t.is(seen[0], elements[0]);
+	t.is(seen[1], elements[1]);
+	t.is(seen[2], elements[2]);
+});
+
+test('subscribe: stop should work', async t => {
+	const e = () => {
+		const element = document.createElement('p');
+		element.className = 'happy-unicorn';
+		return element;
+	};
+
+	const elements = [e(), e(), e()];
+	const seen = [];
+
+	(async () => {
+		document.body.append(elements[0]);
+		await delay(200);
+		document.body.append(elements[1]);
+		await delay(100);
+		document.body.append(elements[2]);
+	})();
+
+	const stop = elementReady.subscribe('.happy-unicorn', el => seen.push(el), {stopOnDomReady: false});
+	await delay(100);
+	stop();
+	await delay(300);
+
+	t.is(seen.length, 1);
+	t.is(seen[0], elements[0]);
+});


### PR DESCRIPTION
This approach uses a `WeakMap` to store already seen elements (to prevent memory leak) in order to detect new elements, also because checking all the elements to find out new ones might be a bit heavy we do this in half of the `requestAnimationFrame`s, feedback is welcome.

Fixes #22


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#22: Subscribe to new elements on the page](https://issuehunt.io/repos/62587127/issues/22)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->