### PR TITLE
Add the `cancellable` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,21 @@ declare namespace elementReady {
 		@default true
 		*/
 		readonly stopOnDomReady?: boolean;
+
+		/**
+		If false, makes the returned promise non-cancellable, doesn't stop on the DOM ready event, and throws an eror on timeout (if provided).
+
+		@default true
+		*/
+		readonly cancellable?: boolean;
+	}
+
+	interface OptionsWithUndefinedCancellable extends Options {
+		readonly cancellable: undefined;
+	}
+
+	interface OptionsWithNonCancellable extends Options {
+		readonly cancellable: false;
 	}
 
 	type StoppablePromise<T> = Promise<T> & {
@@ -38,7 +53,7 @@ declare namespace elementReady {
 Detect when an element is ready in the DOM.
 
 @param selector - [CSS selector.](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_Started/Selectors)
-@returns The matching element, or `undefined` if the element could not be found.
+@returns A promise resolving the matching element, or `undefined` if the element could not be found.
 
 @example
 ```
@@ -54,14 +69,41 @@ import elementReady = require('element-ready');
 */
 declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
 	selector: ElementName,
+	options?: elementReady.OptionsWithUndefinedCancellable
+): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | undefined>;
+declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
+	selector: ElementName,
+	options?: elementReady.OptionsWithNonCancellable
+): Promise<HTMLElementTagNameMap[ElementName] | never>;
+declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
+	selector: ElementName,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | undefined>;
+
+declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
+	selector: ElementName,
+	options?: elementReady.OptionsWithUndefinedCancellable
+): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | undefined>;
+declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
+	selector: ElementName,
+	options?: elementReady.OptionsWithNonCancellable
+): Promise<SVGElementTagNameMap[ElementName] | never>;
 declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
 	selector: ElementName,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | undefined>;
+
+declare function elementReady<ElementName extends Element = Element>(
+	selector: string,
+	options?: elementReady.OptionsWithUndefinedCancellable
+): elementReady.StoppablePromise<ElementName | undefined>;
+declare function elementReady<ElementName extends Element = Element>(
+	selector: string,
+	options?: elementReady.OptionsWithNonCancellable
+): Promise<ElementName | never>;
 declare function elementReady<ElementName extends Element = Element>(
 	selector: string,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<ElementName | undefined>;
+
 export = elementReady;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,15 +1,17 @@
 import {expectType} from 'tsd';
 import elementReady = require('.');
 
-const promise = elementReady('#unicorn');
 elementReady('#unicorn', {target: document});
 elementReady('#unicorn', {target: document.documentElement});
 elementReady('#unicorn', {timeout: 1000000});
-
 elementReady('#unicorn', {stopOnDomReady: false});
+elementReady('#unicorn', {cancellable: false});
 
-expectType<elementReady.StoppablePromise<Element | undefined>>(promise);
+expectType<elementReady.StoppablePromise<Element | undefined>>(elementReady('#unicorn'));
+expectType<elementReady.StoppablePromise<Element | undefined>>(elementReady('#unicorn', {cancellable: true}));
 expectType<elementReady.StoppablePromise<HTMLDivElement | undefined>>(elementReady('div'));
 expectType<elementReady.StoppablePromise<SVGElement | undefined>>(elementReady('text'));
 
-promise.stop();
+expectType<Promise<Element | never>>(elementReady('#unicorn', {cancellable: false}));
+expectType<Promise<HTMLDivElement | never>>(elementReady('div', {cancellable: false}));
+expectType<Promise<SVGElement | never>>(elementReady('text', {cancellable: false}));

--- a/test.js
+++ b/test.js
@@ -187,3 +187,43 @@ test('ensure different promises are returned on second call with the same select
 	document.querySelector('.unicorn').remove();
 	t.is(prependElement(), await elementReady('.unicorn'));
 });
+
+test('Non-cancellable: the promise does not have the stop method', t => {
+	const elementCheck = elementReady('#bio', {
+		cancellable: false
+	});
+
+	t.falsy(elementCheck.stop);
+});
+
+test('Non-cancellable: check if element ready after dom loaded', async t => {
+	const elementCheck = elementReady('#bio', {
+		cancellable: false
+	});
+
+	let element;
+
+	setTimeout(() => {
+		element = document.createElement('p');
+		element.id = 'bio';
+		document.body.append(element);
+	}, 100);
+
+	t.is(await elementCheck, element);
+});
+
+test('Non-cancellable: check if element ready after timeout', async t => {
+	const elementCheck = elementReady('#cheezburger', {
+		cancellable: false,
+		timeout: 1000
+	});
+
+	// The element will be added eventually, but we're not around to wait for it
+	setTimeout(() => {
+		const element = document.createElement('p');
+		element.id = 'cheezburger';
+		document.body.append(element);
+	}, 50000);
+
+	await t.throwsAsync(elementCheck, {instanceOf: Error, message: 'Element \'#cheezburger\' not found'});
+});


### PR DESCRIPTION
(A redo of PR #23, Issue originally mentioned in https://github.com/sindresorhus/caprine/pull/923#discussion_r298812875)

The `cancellable: false` is an option for cases (like in Caprine) where:

* `cancel()` is never called (so Promise doesn’t have to to be cancellable)
* `stopOnDomReady` is always `false`
* `timeout` is either never used, or is expected to throw an error, rather than resolving `undefined`

`elementReady`, when called with `cancellable: false`, has a correct return type, so it’s possible to write this:

```typescript
let element = await elementReady('#test', {cancellable: false});
element.click();
```

Instead of:

```typescript
let element = (await elementReady('#test', {stopOnDomReady: false}))!;
element.click();
```
