### PR TITLE
Use native querySelector types instead of copying them

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ declare function elementReady<
 	Selector extends string,
 	TElement extends Element = QuerySelector<Selector>
 >(
-	selector: string,
+	selector: Selector,
 	options?: elementReady.Options
 ): elementReady.StoppablePromise<TElement | undefined>;
 export = elementReady;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom"/>
 
+type QuerySelector = ParentNode['querySelector'];
+
 declare namespace elementReady {
 	interface Options {
 		/**
@@ -63,16 +65,11 @@ import elementReady = require('element-ready');
 })();
 ```
 */
-declare function elementReady<ElementName extends keyof HTMLElementTagNameMap>(
-	selector: ElementName,
-	options?: elementReady.Options
-): elementReady.StoppablePromise<HTMLElementTagNameMap[ElementName] | undefined>;
-declare function elementReady<ElementName extends keyof SVGElementTagNameMap>(
-	selector: ElementName,
-	options?: elementReady.Options
-): elementReady.StoppablePromise<SVGElementTagNameMap[ElementName] | undefined>;
-declare function elementReady<ElementName extends Element = Element>(
+declare function elementReady<
+	Selector extends string,
+	TElement extends Element = QuerySelector<Selector>
+>(
 	selector: string,
 	options?: elementReady.Options
-): elementReady.StoppablePromise<ElementName | undefined>;
+): elementReady.StoppablePromise<TElement | undefined>;
 export = elementReady;


### PR DESCRIPTION
I'm looking for a way to use querySelector’s own types so that:

- they don't need to be copied to our definitions
- enhanced 4.1 querySelector types would be enabled here as well (via [typed-query-selector](https://github.com/g-plane/typed-query-selector) or [natively](https://github.com/microsoft/TypeScript/issues/29037))

Unfortunately I'm stuck on "Type QuerySelector is not generic":

<img width="491" alt="Type * is not a generic" src="https://user-images.githubusercontent.com/1402241/103195528-14774b00-48a8-11eb-8418-500c41ba938f.png">

Note: We can't use `Parameters<fn>` and such because it doesn't support overloads.