### PR TITLE
Clean getMatchingElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export default function elementReady(selector, {
 
 				// When it's ready, only stop if requested or found
 				if (isDomReady(target) && (stopOnDomReady || element)) {
-					return element ?? undefined; // No `null`
+					return element;
 				}
 
 				let current = element;
@@ -123,7 +123,7 @@ export function observeReadyElements(selector, {
 
 function getMatchingElement({target, selector, predicate}) {
 	if (!predicate) {
-		return target.querySelector(selector);
+		return target.querySelector(selector) ?? undefined; // No `null`
 	}
 
 	for (const element of target.querySelectorAll(selector)) {

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function getMatchingElement({target, selector, predicate}) {
 		return target.querySelector(selector);
 	}
 
-	for (const element of target.querySelectorAll(selector) {
+	for (const element of target.querySelectorAll(selector)} {
 		if (predicate(element)) {
 			return element;
 		}

--- a/index.js
+++ b/index.js
@@ -121,11 +121,14 @@ export function observeReadyElements(selector, {
 	};
 }
 
-function getMatchingElement({target, selector, predicate} = {}) {
-	if (predicate) {
-		const elements = target.querySelectorAll(selector);
-		return [...elements].find(element => predicate(element));
+function getMatchingElement({target, selector, predicate}) {
+	if (!predicate) {
+		return target.querySelector(selector);
 	}
 
-	return target.querySelector(selector);
+	for (const element of target.querySelectorAll(selector) {
+		if (predicate(element)) {
+			return element;
+		}
+	}
 }

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function getMatchingElement({target, selector, predicate}) {
 		return target.querySelector(selector);
 	}
 
-	for (const element of target.querySelectorAll(selector)} {
+	for (const element of target.querySelectorAll(selector)) {
 		if (predicate(element)) {
 			return element;
 		}


### PR DESCRIPTION
Nitpicks only:

- `getMatchingElement` requires target and selector, so `= {}` cannot be used
- `[...x].find()` loops twice and creates a function
- `querySelector()` and therefore `getMatchingElement` return `| null`. This was addressed later in the code, but `null` should be eliminated immediately