### PR TITLE
Fix stop observing elements immediately when aborted

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export function observeReadyElements(selector, {
 					}
 				}
 			} catch (error) {
-				if (!signal.aborted) {
+				if (error.name === 'AbortError' && !signal.aborted) {
 					throw error;
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -60,10 +60,10 @@ async function * consumeAsyncIteratorWithAbortSignal(iterator, signal) {
 		const next = await Promise.race([iterator.next(), abortPromise]); // eslint-disable-line no-await-in-loop
 
 		if (next === aborted || next.done) {
-			return {isAborted: true};
+			return;
 		}
 
-		yield {isAborted: false, value: next.value};
+		yield next.value;
 	}
 }
 
@@ -92,12 +92,8 @@ export function observeReadyElements(selector, {
 				signal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
 			}
 
-			for await (const {isAborted, value: mutation} of consumeAsyncIteratorWithAbortSignal(iterator, signal)) {
-				if (isAborted) {
-					return;
-				}
-
-				for (const element of mutation.addedNodes) {
+			for await (const {addedNodes} of consumeAsyncIteratorWithAbortSignal(iterator, signal)) {
+				for (const element of addedNodes) {
 					if (element.nodeType !== 1 || !element.matches(selector) || (predicate && !predicate(element))) {
 						continue;
 					}

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function * consumeAsyncIteratorWithAbortSignal(iterator, signal) {
 	const abortPromise = new Promise(resolve => {
 		if (signal) {
 			signal.addEventListener('abort', () => {
-				iterator.return();
+				iterator.return(); // Stop iterator from producing values after the next one
 				resolve(aborted);
 			});
 		}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=20"
+		"node": ">=20.3"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=20.3"
+		"node": ">=20"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -41,7 +41,7 @@
 		"domready"
 	],
 	"dependencies": {
-		"dom-mutations": "^1.0.0",
+		"dom-mutations": "^1.0.1",
 		"request-animation-frames": "^1.0.0",
 		"typed-query-selector": "^2.12.0"
 	},

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"domready"
 	],
 	"dependencies": {
-		"dom-mutations": "^1.0.1",
+		"dom-mutations": "^1.0.2",
 		"request-animation-frames": "^1.0.0",
 		"typed-query-selector": "^2.12.0"
 	},

--- a/test.js
+++ b/test.js
@@ -333,3 +333,17 @@ test('subscribe to newly added elements that match a predicate', async t => {
 		}
 	}
 });
+
+test('timeout when subscribed elements never are never added', async t => {
+	const id = composeElementId();
+
+	const readyElements = observeReadyElements(`#${id}`, {stopOnDomReady: false, signal: AbortSignal.timeout(2_000)});
+
+	let readyElementsCount = 0;
+
+	for await (const _ of readyElements) {
+		readyElementsCount++;
+	}
+
+	t.is(readyElementsCount, 0, 'Should not have found any elements');
+});

--- a/test.js
+++ b/test.js
@@ -334,7 +334,7 @@ test('subscribe to newly added elements that match a predicate', async t => {
 	}
 });
 
-test('timeout when subscribed elements never are never added', async t => {
+test('timeout when subscribed elements are never added (timeout)', async t => {
 	const id = composeElementId();
 
 	const readyElements = observeReadyElements(`#${id}`, {stopOnDomReady: false, signal: AbortSignal.timeout(2000)});

--- a/test.js
+++ b/test.js
@@ -363,7 +363,7 @@ test('subscribe to newly added elements that match a predicate', async t => {
 	}
 });
 
-test('timeout when subscribed elements are never added (timeout)', async t => {
+test('timeout when subscribed elements are never added', async t => {
 	const id = composeElementId();
 
 	const readyElements = observeReadyElements(`#${id}`, {stopOnDomReady: false, signal: AbortSignal.timeout(2000)});

--- a/test.js
+++ b/test.js
@@ -337,7 +337,7 @@ test('subscribe to newly added elements that match a predicate', async t => {
 test('timeout when subscribed elements never are never added', async t => {
 	const id = composeElementId();
 
-	const readyElements = observeReadyElements(`#${id}`, {stopOnDomReady: false, signal: AbortSignal.timeout(2_000)});
+	const readyElements = observeReadyElements(`#${id}`, {stopOnDomReady: false, signal: AbortSignal.timeout(2000)});
 
 	let readyElementsCount = 0;
 

--- a/test.js
+++ b/test.js
@@ -374,7 +374,7 @@ test('timeout when subscribed elements are never added (timeout)', async t => {
 		readyElementsCount++;
 	}
 
-  t.is(readyElementsCount, 0, 'Should not have found any elements');
+	t.is(readyElementsCount, 0, 'Should not have found any elements');
 });
 
 test('subscribe to newly added elements that match one of multiple selectors', async t => {


### PR DESCRIPTION
Depends on https://github.com/sindresorhus/dom-mutations/pull/1, https://github.com/sindresorhus/dom-mutations/pull/3

`iterator.return()` only affects the next time the iterator returns ([this is a bug with `dom-mutations`](https://github.com/sindresorhus/dom-mutations/pull/1)). If it is aborted, we should return immediately. It looks like this was a problem even before using `AbortSignal`s, but we never tested it.

Since `domMutations` accepts an `AbortSignal`, we can just do that, and it works.

Otherwise, we could've created a helper function that races an abortion promise alongside the iterator:

```js
async function * consumeAsyncIteratorWithAbortSignal(iterator, signal) {
	const aborted = Symbol('aborted');

	const abortPromise = new Promise(resolve => {
		if (signal) {
			signal.addEventListener('abort', () => {
				iterator.return(); // Stop iterator from producing values after the next one
				resolve(aborted);
			});
		}
	});

	while (true) {
		const next = await Promise.race([iterator.next(), abortPromise]); // eslint-disable-line no-await-in-loop

		if (next === aborted || next.done) {
			return;
		}

		yield next.value;
	}
}
```

Fixes #52