### PR TITLE
Fix `waitForChildren` resolving prematurely due to ancestor siblings

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export default async function elementReady(selector, {
 		}
 
 		// When `waitForChildren` is enabled, resolve only once the element is guaranteed to be fully parsed.
-		if (element && isChildrenReady({element, target, waitForChildren})) {
+		if (element && (!waitForChildren || isChildrenReady({element, target}))) {
 			return element;
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
 import requestAnimationFrames from 'request-animation-frames';
 import domMutations from 'dom-mutations';
 
-const isDomReady = target =>
-	['interactive', 'complete'].includes((target.ownerDocument ?? target).readyState);
+const getOwnerDocument = target => {
+	if (target?.nodeType === Node.DOCUMENT_NODE) {
+		return target;
+	}
+
+	return target?.ownerDocument ?? target?.host?.ownerDocument;
+};
+
+const isDomReady = target => {
+	const ownerDocument = getOwnerDocument(target);
+	return ownerDocument ? ['interactive', 'complete'].includes(ownerDocument.readyState) : false;
+};
 
 export default async function elementReady(selector, {
 	target = document,
@@ -33,8 +43,8 @@ export default async function elementReady(selector, {
 			return element;
 		}
 
-		// Only check the element's own nextSibling, not ancestors, to avoid false positives
-		if (element && (!waitForChildren || element.nextSibling)) {
+		// When `waitForChildren` is enabled, resolve only once the element is guaranteed to be fully parsed.
+		if (element && isChildrenReady({element, target, waitForChildren})) {
 			return element;
 		}
 	}
@@ -85,8 +95,8 @@ export function observeReadyElements(selector, {
 						continue;
 					}
 
-					// Only check the element's own nextSibling, not ancestors, to avoid false positives
-					if (!waitForChildren || element.nextSibling) {
+					// Match the same "fully parsed" behavior as `elementReady()`.
+					if (isChildrenReady({element, target, waitForChildren})) {
 						yield element;
 					}
 				}
@@ -105,4 +115,32 @@ function getMatchingElement({target, selector, predicate}) {
 			return element;
 		}
 	}
+}
+
+function isChildrenReady({element, target, waitForChildren}) {
+	if (!waitForChildren) {
+		return true;
+	}
+
+	const ownerDocument = getOwnerDocument(target) ?? element.ownerDocument;
+	if (ownerDocument?.readyState !== 'loading') {
+		return true;
+	}
+
+	// Consider the element "fully parsed" once it, or any ancestor within `target`, has a next sibling.
+	// Ignore `document.head` as it has a `nextSibling` (`body`) from the start, which is not a parsing signal.
+	let current = element;
+	while (current) {
+		if (current === target || current === ownerDocument?.head) {
+			return false;
+		}
+
+		if (current.nextSibling) {
+			return true;
+		}
+
+		current = current.parentNode;
+	}
+
+	return false;
 }

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ export function observeReadyElements(selector, {
 					}
 
 					// Match the same "fully parsed" behavior as `elementReady()`.
-					if (isChildrenReady({element, target, waitForChildren})) {
+					if (!waitForChildren || isChildrenReady({element, target})) {
 						yield element;
 					}
 				}
@@ -117,13 +117,9 @@ function getMatchingElement({target, selector, predicate}) {
 	}
 }
 
-function isChildrenReady({element, target, waitForChildren}) {
-	if (!waitForChildren) {
-		return true;
-	}
-
+function isChildrenReady({element, target}) {
 	const ownerDocument = getOwnerDocument(target) ?? element.ownerDocument;
-	if (ownerDocument?.readyState !== 'loading') {
+	if (isDomReady(ownerDocument ?? element)) {
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #62

The sibling check now properly waits for DOM ready when no ancestor has siblings (the refined-github case). Also stops at the `target` boundary and excludes `document.head`. Added a test that directly simulates the refined-github scenario.
